### PR TITLE
Update Rank.cs

### DIFF
--- a/Dualog.Shared/Enums/Rank.cs
+++ b/Dualog.Shared/Enums/Rank.cs
@@ -3,8 +3,11 @@
     public enum Rank
     {
         Captain,
-        Officer,
-        Rating,
-        Specialist
+        ChiefEngineer,
+        ChiefOfficer,
+        SecondOfficer,
+        FirstEngineer,
+        Steward,
+        Fisherman
     }
 }


### PR DESCRIPTION
Customers want seafarers ranks for the crew members.
This is not important for SafeSeaNet purposes but it is only for respecting the differences in the seafarers professions and ranks.